### PR TITLE
[feature] Upgrade php and wordpress version

### DIFF
--- a/epfl-404.php
+++ b/epfl-404.php
@@ -9,7 +9,7 @@
 require_once('inc/epfl-404-db.php');
 require_once('inc/epfl-404-table.php');
 
-
+#[AllowDynamicProperties]
 class EPFL404
 {
     static $instance;

--- a/epfl-404.php
+++ b/epfl-404.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL-404
  * Description: To log 404 pages
- * @version: 0.4
+ * @version: 0.5
  * @copyright: Copyright (c) 2018 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 


### PR DESCRIPTION
In PHP 8.2, dynamic Properties are deprecated.
To allow them we need attribute `#[AllowDynamicProperties]` on the class.

https://php.watch/versions/8.2/dynamic-properties-deprecated